### PR TITLE
Update docs: Format titles and links for github compatiblity

### DIFF
--- a/g3doc/base-tech.md
+++ b/g3doc/base-tech.md
@@ -55,7 +55,7 @@ TransformSystem* transform_system = registry.Get<TransformSystem>();
 
 Because the Registry owns all these high-level runtime objects, it can be
 considered the primary representation of Lullaby in an application's runtime.
-All [Systems](./ecs.md#system) and most other key libraries depend on the Registry
+All [Systems](ecs.md#system) and most other key libraries depend on the Registry
 to interact with each other.
 
 

--- a/g3doc/base-tech.md
+++ b/g3doc/base-tech.md
@@ -5,10 +5,10 @@ information about these libraries is available in their respective header files.
 
 [TOC]
 
-## TypeId {#typeid}
+## TypeId
 
 Lullaby's TypeId framework is a light-weight mechanism for getting [runtime type
-information (RTTI)](https://en.wikipedia.org/wiki/Run-time_type_information).
+information (RTTI)](https://en.wikipedia.org/wiki/Run-time_type_information.md).
 Classes have to explicitly opt-in to the framework by using the
 LULLABY_SETUP_TYPE macro.  For example:
 
@@ -31,7 +31,7 @@ GetTypeName<T>().  For example:
 std::cout << lull::GetTypeName<MyClass>();
 ```
 
-## Registry {#registry}
+## Registry
 
 The Registry is used as a light-weight [dependency injection]
 (https://en.wikipedia.org/wiki/Dependency_injection) framework.  All
@@ -55,11 +55,11 @@ TransformSystem* transform_system = registry.Get<TransformSystem>();
 
 Because the Registry owns all these high-level runtime objects, it can be
 considered the primary representation of Lullaby in an application's runtime.
-All [Systems](ecs#system) and most other key libraries depend on the Registry
+All [Systems](./ecs.md#system) and most other key libraries depend on the Registry
 to interact with each other.
 
 
-## Dispatcher {#dispatcher}
+## Dispatcher
 
 The Dispatcher is Lullaby's [message passing]
 (https://en.wikipedia.org/wiki/Message_passing) framework and is used to enable

--- a/g3doc/ecs.md
+++ b/g3doc/ecs.md
@@ -2,7 +2,7 @@
 
 [TOC]
 
-## Introduction {intro}
+## Introduction
 
 At its core, Lullaby uses an [Entity-Component-System]
 (https://en.wikipedia.org/wiki/Entity%E2%80%93component%E2%80%93system) (ECS)
@@ -19,10 +19,10 @@ for an efficient runtime.
 
 This page describes the various classes and concepts that make up Lullaby's
 ECS architecture. It assumes that you have read the brief ECS [introduction]
-(introduction#systems).
+(introduction.md#systems).
 
 
-#### A Note on Terminology {terminology}
+#### A Note on Terminology
 
 It is unfortunate that the terms [Component](#component) and [System](#system)
 are rather generic since they have many meanings in software engineering.
@@ -33,7 +33,7 @@ Entity-Component-System, we will captilize the terms, whereas we will just say
 "component" and "system" when discussing other things.
 
 
-## Entity {entity}
+## Entity
 
 An **Entity** represents a single, uniquely identifiable "thing" in the virtual
 reality world.
@@ -51,7 +51,7 @@ data. All [Components](#component) that map to the same Entity value can be
 considered as "belonging" to that Entity.
 
 
-## Component {component}
+## Component
 
 **Components** encapsulate a set of data that represents a single aspect of an
 [Entity](#entity).
@@ -72,7 +72,7 @@ the same position data can be used by a Collision System to determine when two
 [Entities](#entity) are intersecting.
 
 
-## System {system}
+## System
 
 A **System** provides the logic for a single aspect of an [Entity](#entity).
 Systems operate on one or more [Components](#component) to provide [Entities]
@@ -92,7 +92,7 @@ System may actually store zero, one or more [Component](#component) data
 instances for any given [Entity](#entity).
 
 
-## Blueprints {blueprint}
+## Blueprints
 
 A **Blueprint** represents the serialized state of an [Entity](#entity). This
 serialized state is effectively a snapshot of all the [Component](#component)
@@ -104,7 +104,7 @@ A Blueprint is not specific to a single [Entity](#entity) instance; multiple
 [Entities](#entity) can be instantiated in the runtime from the same Blueprint.
 
 
-## Schemas {schema}
+## Schemas
 
 Lullaby uses the [FlatBuffers](https://google.github.io/flatbuffers) library to
 serialize and store [Blueprints](#blueprint). The FlatBuffers library uses
@@ -119,7 +119,7 @@ Information on how to write a Schema can be found [here]
 In Lullaby, most [Schemas](#schema) are named with a "Def" suffix because they
 are data defintions; they describe the structure of data.
 
-## EntityDefs and ComponentDefs {entity-def}
+## EntityDefs and ComponentDefs
 
 As described above, a [Blueprint](#blueprint) represents the serialized state of
 an [Entity](#entity).  The [Schema](#schema) that describes an Entity
@@ -178,7 +178,7 @@ they are easy to understand), but are converted into quaternions when stored in
 the [System](#system).
 
 
-## Entity Factory {entity-factory}
+## Entity Factory
 
 The **EntityFactory** is responsible for "creating" [Entities](#entity) from
 [Blueprints](#blueprint).  A [Blueprint](#blueprint) can exist in one of three
@@ -198,7 +198,7 @@ The C++ Blueprint class can be used to create, load and save [Blueprints]
 
 To "create" an [Entity](#entity), the EntityFactory first generates a new
 unique number for the [Entity](#entity).  It then iterates over the
-[ComponentDefs](#entity-def) stored in the [Blueprint](#blueprint), passing them
+[ComponentDefs](#entitydefs-and-componentdefs) stored in the [Blueprint](#blueprint), passing them
 to their owning [System](#system) along with the newly generated [Entity]
 (#entity) ID.  The [System](#system) is then responsible for creating the
 corresponding [Components](#components) internally and associating them with
@@ -207,4 +207,3 @@ the given [Entity](#entity).
 The EntityFactory can also "destroy" an [Entity](#entity) by simply requesting
 all [Systems](#systems) to destroy any [Components](#component) associated with
 the given [Entity](#entity).
-

--- a/g3doc/index.md
+++ b/g3doc/index.md
@@ -25,16 +25,15 @@ and augmented reality experiences.
 
 ## Getting Started
 
-Start with the [Introduction](introduction) which provides a high-level
+Start with the [Introduction](introduction.md) which provides a high-level
 overview of the Lullaby architecture.
 
-Learn how to [build](building) the Lullaby libraries.
+Learn how to [build](building.md) the Lullaby libraries.
 
 
-The [Integration Guide](integration-guide) will provide a step-by-step
+The [Integration Guide](integration-guide.md) will provide a step-by-step
 process for adding Lullaby to your app.
 
 
-Finally, explore the [List of Systems](list-of-systems) to get a sense of what
+Finally, explore the [List of Systems](list-of-systems.md) to get a sense of what
 Lullaby can do for you.
-

--- a/g3doc/integration-guide.md
+++ b/g3doc/integration-guide.md
@@ -5,7 +5,7 @@
 ## Introduction
 
 This document provides a step-by-step guide for integrating Lullaby with your
-project.  It assumes you have read the [Introduction](introduction) and are
+project.  It assumes you have read the [Introduction](introduction.md) and are
 familiar with the basic concepts and technologies used by Lullaby.
 
 Before we begin, it's important to understand a bit of Lullaby's design goals.
@@ -43,12 +43,12 @@ decisions.  So let's get started.
 
 ### Create the Registry
 
-The [Registry](base-tech#registry) owns all other high-level Lullaby objects and
+The [Registry](base-tech.md#registry) owns all other high-level Lullaby objects and
 allows them to access each other.  In some ways, it can be thought of as a proxy
-to Lullaby itself.  When the [Registry](base-tech#registry) is destroyed, it
+to Lullaby itself.  When the [Registry](base-tech.md#registry) is destroyed, it
 will destroy all objects that it owns.
 
-You can create the [Registry](base-tech#registry) quite simply:
+You can create the [Registry](base-tech.md#registry) quite simply:
 
 ```c++
   lull::Registry registry;
@@ -56,8 +56,8 @@ You can create the [Registry](base-tech#registry) quite simply:
 
 ### Create the Entity Factory
 
-The [Entity Factory](ecs#entity-factory) is responsible for the creation of
-[Entities](ecs#entity) and, as such, is a critical component of any Lullaby
+The [Entity Factory](ecs.md#entity-factory) is responsible for the creation of
+[Entities](ecs.md#entity) and, as such, is a critical component of any Lullaby
 integration.
 
 ```c++
@@ -66,13 +66,13 @@ integration.
 
 ### Create the Dispatcher
 
-The [Dispatcher](base-tech#dispatcher) enables Lullaby [Systems](ecs#system) to
-communicate with each other. While the [Registry](ecs#registry) allows [Systems]
-(ecs#system) to directly access and call functions on each other, the
-[Dispatcher](base-tech#dispatcher) can be used to reduce [coupling]
+The [Dispatcher](base-tech.md#dispatcher) enables Lullaby [Systems](ecs.md#system) to
+communicate with each other. While the [Registry](ecs.md#registry) allows [Systems]
+(ecs.md#system) to directly access and call functions on each other, the
+[Dispatcher](base-tech.md#dispatcher) can be used to reduce [coupling]
 (https://en.wikipedia.org/wiki/Coupling_(computer_programming)) and allow for
-greater flexibility in design. (For example, a [System](ecs#system) can send
-a "ClickEvent" without having to know what other [Systems](ecs#system) need to
+greater flexibility in design. (For example, a [System](ecs.md#system) can send
+a "ClickEvent" without having to know what other [Systems](ecs.md#system) need to
 be notified.)
 
 ```c++
@@ -81,11 +81,11 @@ be notified.)
 
 ### Create the Asset Loader
 
-The [Asset Loader](base-tech#asset-loader) is used to load all assets (eg.
-textures, shaders, audio files, [Blueprints](ecs#blueprint), etc.) in the
+The [Asset Loader](base-tech.md#asset-loader) is used to load all assets (eg.
+textures, shaders, audio files, [Blueprints](ecs.md#blueprint), etc.) in the
 runtime. It supports both synchronous and asynchronous loading.
 
-The [Asset Loader](base-tech#asset-loader) is optional if you do not require
+The [Asset Loader](base-tech.md#asset-loader) is optional if you do not require
 any assets (though that seems unlikely as even the most basic rendering requires
 loading a shader at the very least.)
 
@@ -95,11 +95,11 @@ loading a shader at the very least.)
 
 ### Create the Input Manager
 
-The [Input Manager](base-tech#input-manager) provides Lullaby libraries a way to
+The [Input Manager](base-tech.md#input-manager) provides Lullaby libraries a way to
 query input device (eg. head-mounted display, 3dof controller, etc.) state with
 having to be aware of the actual specifics of the underlying hardware APIs.
 
-The [Input Manager](base-tech#input-manager) is optional if you are not going to
+The [Input Manager](base-tech.md#input-manager) is optional if you are not going to
 use any Systems that process input, but for any type of interactive application,
 you will need it.
 
@@ -109,9 +109,9 @@ you will need it.
 
 ### Initialize the Entity Factory
 
-Lastly, you must initialize the [Entity Factory](ecs#entity-factory).  More
+Lastly, you must initialize the [Entity Factory](ecs.md#entity-factory).  More
 information about the purpose of this call, and why it is separate from the
-[Entity Factory](ecs#entity-factory) constructor, is provided in the sections
+[Entity Factory](ecs.md#entity-factory) constructor, is provided in the sections
 further below.
 
 ```c++
@@ -129,16 +129,16 @@ Remember that you can get a pointer to an object when you call
 
 ### Queued Dispatcher
 
-The [Dispatcher](base-tech#dispatcher) by default is an "immediate" [Dispatcher]
-(base-tech#dispatcher). When you send an Event to an "immediate" [Dispatcher]
-(base-tech#dispatcher), that Event is processed by the associated event handlers
+The [Dispatcher](base-tech.md#dispatcher) by default is an "immediate" [Dispatcher]
+(base-tech.md#dispatcher). When you send an Event to an "immediate" [Dispatcher]
+(base-tech.md#dispatcher), that Event is processed by the associated event handlers
 during the call to ```Dispatcher::Send```.
 
-However, it is often desirable for the [Dispatcher](base-tech#dispatcher) stored
-in the [Registry](base-tech#registry) to be a "queued" [Dispatcher]
-(base-tech#dispatcher) as this provides explicit control of when the Events are
-are actually processed. To create a "queued" [Dispatcher](base-tech#dispatcher),
-instead of an "immediate" [Dispatcher](base-tech#dispatcher), just do the
+However, it is often desirable for the [Dispatcher](base-tech.md#dispatcher) stored
+in the [Registry](base-tech.md#registry) to be a "queued" [Dispatcher]
+(base-tech.md#dispatcher) as this provides explicit control of when the Events are
+are actually processed. To create a "queued" [Dispatcher](base-tech.md#dispatcher),
+instead of an "immediate" [Dispatcher](base-tech.md#dispatcher), just do the
 following:
 
 ```c++
@@ -155,7 +155,7 @@ You can then explicitly process the queued Events by calling:
 ### Load Function
 
 You can provide your own function that performs the actual loading done by the
-[Asset Loader](base-tech#asset-loader).
+[Asset Loader](base-tech.md#asset-loader).
 
 
 ### Input Devices
@@ -164,39 +164,39 @@ You can provide your own function that performs the actual loading done by the
 ## Adding Systems
 
 The majority of Lullaby's functionality is provided through its [Systems]
-(ecs#system). While Lullaby provides a variety of [Systems](ecs#system), not all
+(ecs.md#system). While Lullaby provides a variety of [Systems](ecs.md#system), not all
 of them are needed for a given application. You are free to choose which
-[Systems](ecs#system) you want to use. Furthermore, you will probably need to
-write some [Systems](ecs#system) of your own. Lullaby provides common, low-level
-[Systems](ecs#system), but the high-level "business logic" [Systems](ecs#system)
+[Systems](ecs.md#system) you want to use. Furthermore, you will probably need to
+write some [Systems](ecs.md#system) of your own. Lullaby provides common, low-level
+[Systems](ecs.md#system), but the high-level "business logic" [Systems](ecs.md#system)
 are provided by you.
 
 Once you've decided that you need the functionality provided by a particular
-[Systems](ecs#system), you can create it via the [Entity Factory]
-(ecs#entity-factory) like so:
+[Systems](ecs.md#system), you can create it via the [Entity Factory]
+(ecs.md#entity-factory) like so:
 
 ```c++
   entity_factory->Create<lull::TransformSystem>(&registry);
 ```
 
-Internally, the [Entity Factory] will instantiate the [System](ecs#system) using
+Internally, the [Entity Factory] will instantiate the [System](ecs.md#system) using
 the ```Registry::Create()``` function. It will also store a pointer to the
-created [System](ecs#system) for its own use.
+created [System](ecs.md#system) for its own use.
 
-You must create all [Systems](ecs#system) before calling
+You must create all [Systems](ecs.md#system) before calling
 ```EntityFactory::Initialize()```.
 
-Finally, keep in mind that different [Systems](ecs#system) have specific
+Finally, keep in mind that different [Systems](ecs.md#system) have specific
 requirements as to when and how they are to be used. For example, some may need
 specific configuration, and some may need to be "updated" once per frame. Please
-ensure you review and understand the API for all your [Systems](ecs#system) that
+ensure you review and understand the API for all your [Systems](ecs.md#system) that
 you plan to use.
 
 
 ## Data-driven Entity Creation
 
-While it is possible create [Entities](ecs#entity) at runtime, it is generally
-preferred that they are created via data [Blueprints](ecs#blueprint). The
+While it is possible create [Entities](ecs.md#entity) at runtime, it is generally
+preferred that they are created via data [Blueprints](ecs.md#blueprint). The
 following steps will allow you to enable this functionality.
 
 ### Entity Schema
@@ -204,7 +204,7 @@ following steps will allow you to enable this functionality.
 You first need to write a [FlatBuffers](https://google.github.io/flatbuffers)
 [Schema File]
 (https://google.github.io/flatbuffers/flatbuffers_guide_writing_schema.html)
-that defines the structure of the [Blueprints](ecs#blueprints)
+that defines the structure of the [Blueprints](ecs.md#blueprints)
 
 ```
 union ComponentDefType {
@@ -216,10 +216,10 @@ union ComponentDefType {
 ```
 
 This file is specific to your application. In the same way that you decide
-which [Systems](ecs#systems) you want to have in your runtime, you also decide
-which [ComponentDefs](ecs#entity-def) you want to allow in your [Blueprints]
-(ecs#blueprint). Generally speaking, you want your [ComponentDefs]
-(ecs#entity-def) to match your [Systems](ecs#system).
+which [Systems](ecs.md#systems) you want to have in your runtime, you also decide
+which [ComponentDefs](ecs.md#entitydefs-and-componentdefs) you want to allow in your [Blueprints]
+(ecs.md#blueprint). Generally speaking, you want your [ComponentDefs]
+(ecs.md#entitydefs-and-componentdefs) to match your [Systems](ecs.md#system).
 
 Then, simple add the following "boiler-plate" to the rest of your schema file.
 
@@ -235,10 +235,10 @@ root_type EntityDef;
 
 ### EntityFactory::Initialize
 
-Because the [EntityDef](ecs#entity-def) is specific to your application, you
-need to provide the [Entity Factory](ecs#entity-factory) with the necesssary
-information to create [Entities](ecs#entity) from your [Blueprints]
-(ecs#blueprint). You do this by calling ```EntityFactory::Initialize()``` in
+Because the [EntityDef](ecs.md#entitydefs-and-componentdefs) is specific to your application, you
+need to provide the [Entity Factory](ecs.md#entity-factory) with the necesssary
+information to create [Entities](ecs.md#entity) from your [Blueprints]
+(ecs.md#blueprint). You do this by calling ```EntityFactory::Initialize()``` in
 a slightly different way:
 
 ```c++
@@ -255,14 +255,14 @@ There are 2 template arguments and 2 function arguments:
 * EnumNamesComponentDefType: This function is generated by flatc and returns an
   array of names that corresponds to the ComponentDefType union.
 
-With this information, the [Entity Factory](ecs#entity-factory) is able to load
-convert a raw binary asset into a [Blueprint](ecs#blueprint) in order to create
-an [Entity](ecs#entity).
+With this information, the [Entity Factory](ecs.md#entity-factory) is able to load
+convert a raw binary asset into a [Blueprint](ecs.md#blueprint) in order to create
+an [Entity](ecs.md#entity).
 
 
-## Updating Lullaby {updating}
+## Updating Lullaby
 
-Now that you've setup everything and can create [Entities](ecs#entity), the only
+Now that you've setup everything and can create [Entities](ecs.md#entity), the only
 thing left to do is start updating them. The general "flow" of a single frame
 update for Lullaby is something like:
 
@@ -275,7 +275,7 @@ update for Lullaby is something like:
 
 ### Calculate Delta Time
 
-Many Lullaby [Systems](ecs#system) need to know the duration that has elapsed
+Many Lullaby [Systems](ecs.md#system) need to know the duration that has elapsed
 since the last time they were updated. As such, it is important to track this
 information in your main loop.
 
@@ -288,7 +288,7 @@ information in your main loop.
 
 ### Update Input Manager
 
-To update the [Input Manager](base-tech#input-manager), you first need to read
+To update the [Input Manager](base-tech.md#input-manager), you first need to read
 your hardware state (using whatever SDKs you want) and "update" the
 corresponding device state in the input manager.  For example:
 
@@ -315,7 +315,7 @@ Then, simply, "swap" the Input Manager buffers by calling:
 ### Dispatch Queued Dispatchers
 
 As mentioned above, you can dispatch any Events queued in your [Dispatcher]
-(base-tech#dispatcher) by calling:
+(base-tech.md#dispatcher) by calling:
 
 ```c++
   queued_dispatcher->Dispatch();
@@ -327,7 +327,7 @@ simulation begins.
 ### Advance Simulation
 
 Call the appropriate ```AdvanceFrame``` (or equivalent) functions in the various
-[Systems](ecs#system) you've created.
+[Systems](ecs.md#system) you've created.
 
 ### Present Output
 
@@ -337,4 +337,3 @@ This step takes the current "state" of the simulation and pushes that data to
 ## Conclusion
 
 And that's basically it.
-

--- a/g3doc/introduction.md
+++ b/g3doc/introduction.md
@@ -29,69 +29,69 @@ At a high level, Lullaby's architecture can be divided into 3 broad categories:
 [Systems](#systems), [Base Tech](#base-tech), and [Utilities](#utilities).
 
 
-#### Systems {systems}
+#### Systems
 
 Lullaby's primary goal is to provide an efficient, data-driven way to create,
 manipulate, and interact with objects in a "virtual" world. For this, Lullaby
 uses an [Entity-Component-System]
 (https://en.wikipedia.org/wiki/Entity%E2%80%93component%E2%80%93system) (ECS)
-architecture. An ECS consists of three parts: [Entities](ecs#entity),
-[Components](ecs#component), and [Systems](ecs#system).
+architecture. An ECS consists of three parts: [Entities](ecs.md#entity),
+[Components](ecs.md#component), and [Systems](ecs.md#system).
 
-An [Entity](ecs#entity) represents a single, uniquely identifiable "thing" in
-the virtual reality world. However, an [Entity](ecs#entity) is literally just a
+An [Entity](ecs.md#entity) represents a single, uniquely identifiable "thing" in
+the virtual reality world. However, an [Entity](ecs.md#entity) is literally just a
 number; it has no other data on its own. Instead, specific pieces of data (like
 position, or velocity, or shape) are associated with an Entity at runtime.
-These data objects are called [Components](ecs#component). Lastly, [Systems]
-(ecs#system) process and update [Components](ecs#component), effectively giving
-[Entities](ecs#entity) their behaviours.  In other
-words, the behaviour of an [Entity](ecs#entity) is a result of the [Components]
-(ecs#components) associated with it and the [Systems](ecs#system) which operate
-on those [Compeonents](ecs#component).
+These data objects are called [Components](ecs.md#component). Lastly, [Systems]
+(ecs.md#system) process and update [Components](ecs.md#component), effectively giving
+[Entities](ecs.md#entity) their behaviours.  In other
+words, the behaviour of an [Entity](ecs.md#entity) is a result of the [Components]
+(ecs.md#components) associated with it and the [Systems](ecs.md#system) which operate
+on those [Compeonents](ecs.md#component).
 
-[Systems](ecs#system) provide all the actual functions and behaviours. Each
-[System](ecs#system) is specialized to perform a specific job, such as playing
-animations, rendering graphics or detecting collisions. [Systems](ecs#system)
+[Systems](ecs.md#system) provide all the actual functions and behaviours. Each
+[System](ecs.md#system) is specialized to perform a specific job, such as playing
+animations, rendering graphics or detecting collisions. [Systems](ecs.md#system)
 perform these tasks by processing one or more types of [Components]
-(ecs#component). A [Component](ecs#component) defines a set of properties, such
+(ecs.md#component). A [Component](ecs.md#component) defines a set of properties, such
 as 3D position, render shape, or interaction state. A collection of [Components]
-(ecs#component) is associated with an [Entity](ecs#entity). An [Entity]
-(ecs#entity) represents a single, uniquely identifiable "thing" in the virtual
-reality world. However, an [Entity](ecs#entity) is literally just a number; it
-has no other data on its own. The behaviour of an [Entity](ecs#entity) is
-defined by the [Components](ecs#component) associated with it and the [Systems]
-(ecs#system) which operate on those [Components](ecs#component).
+(ecs.md#component) is associated with an [Entity](ecs.md#entity). An [Entity]
+(ecs.md#entity) represents a single, uniquely identifiable "thing" in the virtual
+reality world. However, an [Entity](ecs.md#entity) is literally just a number; it
+has no other data on its own. The behaviour of an [Entity](ecs.md#entity) is
+defined by the [Components](ecs.md#component) associated with it and the [Systems]
+(ecs.md#system) which operate on those [Components](ecs.md#component).
 
 For example, a Physics System could update the position of all [Entities]
-(ecs#entity) with both position and velocity [Components](ecs#component), or a
-Render System would render [Entities] (ecs#entity) using the positon and shape
-[Components](ecs#component).
+(ecs.md#entity) with both position and velocity [Components](ecs.md#component), or a
+Render System would render [Entities] (ecs.md#entity) using the positon and shape
+[Components](ecs.md#component).
 
 Lullaby also has an offline data representation that enables fast data-driven
 iteration of its Entity-Component-System architecture. Applications use data
-files known as [Blueprints](ecs#blueprint) to describe the state of an Entity
-that can then be instantiated in the runtime.  [Schema](ecs#blueprint) files are
+files known as [Blueprints](ecs.md#blueprint) to describe the state of an Entity
+that can then be instantiated in the runtime.  [Schema](ecs.md#blueprint) files are
 used to describe the structure of the data contained in a [Blueprint]
-(ecs#blueprint).
+(ecs.md#blueprint).
 
 The bulk of Lullaby's functionality is implemented as individual [Systems]
-(ecs#system), such as the [TransformSystem](../src/systems/transform),
+(ecs.md#system), such as the [TransformSystem](../src/systems/transform),
 [AudioSystem](../src/systems/audio), [RenderSystem](../src/systems/render), and
 [AnimationSystem](../src/systems/animation). A complete list of [Systems]
-(ecs#system) can be found [here](list-of-systems).
+(ecs.md#system) can be found [here](list-of-systems.md).
 
-Details about Lullaby's ECS implementation can be found [here](ecs).
+Details about Lullaby's ECS implementation can be found [here](ecs.md).
 
-A list of available Systems can be found [here](list-of-systems).
+A list of available Systems can be found [here](list-of-systems.md).
 
-#### Base Tech {base-tech}
+#### Base Tech
 
 Lullaby's [Systems](#systems) often require access to a common set of
 functionality in order to work with each other. This functionality, along with
 the ECS implementation, represent the "base" of the Lullaby Engine.  It is
 important for users of Lullaby to have a good understanding these libraries.
 
-More information about these base libraries can be found [here](base-tech).
+More information about these base libraries can be found [here](base-tech.md).
 
 
 #### Utilities
@@ -133,10 +133,9 @@ Finally, the rest of the folders are:
 
 ## Building
 
-Instructions on building the Lullaby libraries is available [here](building).
+Instructions on building the Lullaby libraries is available [here](building.md).
 
 ## Putting it all Together
 
-Follow our step-by-step [Integration Guide](integration-guide) for how to
+Follow our step-by-step [Integration Guide](integration-guide.md) for how to
 integrate Lullaby into your application.
-

--- a/g3doc/list-of-systems.md
+++ b/g3doc/list-of-systems.md
@@ -1,7 +1,7 @@
 # List of Systems
 
-The following is a list of [Systems](ecs#system) that are available in the
-Lullaby repository.  Detailed documentation for individual [Systems](ecs#system)
+The following is a list of [Systems](ecs.md#system) that are available in the
+Lullaby repository.  Detailed documentation for individual [Systems](ecs.md#system)
 is available in their respective folders.
 
 System                                              | Description


### PR DESCRIPTION
The markdown links were not compatible with github, making browsing a pain. Unlike the other PR open for this, this fixes all the docs.

- attach .md file suffix to markdown links, to allow them to be followed to the correct page.
- remove extraneous anchors from headings.